### PR TITLE
setting a common minimum array length.

### DIFF
--- a/helper/utils.js
+++ b/helper/utils.js
@@ -32,8 +32,20 @@ internals.ranchSystemsTransform = (sourcePayload, rb) => {
     const _48inProbeIndexLocation = _.findIndex(data, ['id', _48inProbeId]);
     const _60inProbeIndexLocation = _.findIndex(data, ['id', _60inProbeId]);
     const _0To100PSIProbeIndexLocation = _.findIndex(data, [ 'id',  _0To100PSIProbeId]);
+    
+    const arrIndexLengths = [
+        data[_4inProbeIndexLocation].rmsdata.length, 
+        data[_12inProbeIndexLocation].rmsdata.length, 
+        data[_24inProbeIndexLocation].rmsdata.length, 
+        data[_36inProbeIndexLocation].rmsdata.length, 
+        data[_48inProbeIndexLocation].rmsdata.length, 
+        data[_60inProbeIndexLocation].rmsdata.length, 
+        data[_0To100PSIProbeIndexLocation].rmsdata.length
+    ];
+    
+    const minCommonLength = Math.min(...arrIndexLengths);
 
-    for (let i = 0; i < data[_4inProbeIndexLocation].rmsdata.length; i++) {
+    for (let i = 0; i < minCommonLength; i++) {
 
         transformedPayload.push({
             "date": moment(new Date(data[_4inProbeIndexLocation].rmsdata[i].x)).format(targetDateStringFormat),


### PR DESCRIPTION
Some requests were failing to return data as a array overflow error was occurring.  Basically when querying data from the ranch systems api no all the data that returns for each of the requested sensors come back with the equal amount of data.  Sometimes one sensor will have 66 values but another will have 65 values.  This different makes it where when we loop through values in our transformation that we start looking for invalid locations which causes errors that fail to return data.  

To fix this issue, the code will now seek the smallest array length before starting to iterate through values.  This will ensure we don't have this issues again.  Test locally confirms this is working as expected. 